### PR TITLE
yt-dlp: Implement Clapper "Playlistable" interface

### DIFF
--- a/src/yt-dlp/clapper_yt_dlp_playlist.py
+++ b/src/yt-dlp/clapper_yt_dlp_playlist.py
@@ -1,0 +1,28 @@
+# Clapper Enhancer yt-dlp
+# Copyright (C) 2025 Rafał Dzięgiel <rafostar.github@gmail.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, see
+# <https://www.gnu.org/licenses/>.
+
+import io, json
+
+def generate_manifest(info):
+    # Check if playlist is requested
+    if not ((val := info.get('_type')) and val == 'playlist'):
+        return None
+
+    manifest = io.StringIO()
+    manifest.write(json.dumps(info))
+
+    return manifest.getvalue()

--- a/src/yt-dlp/meson.build
+++ b/src/yt-dlp/meson.build
@@ -6,6 +6,7 @@ enhancer_data += [
   'yt-dlp/clapper_yt_dlp_dash.py',
   'yt-dlp/clapper_yt_dlp_hls.py',
   'yt-dlp/clapper_yt_dlp_direct.py',
+  'yt-dlp/clapper_yt_dlp_playlist.py',
 ]
 
 # Enhancer code has Clapper version checks


### PR DESCRIPTION
Adds support for YouTube URIs with playlists, recent channel videos and even website search queries