### PR TITLE
meson: Versioning for git builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('clapper-enhancers', 'c',
-  version: '0.8.2', # major and minor numbers indicate required libclapper version
+  version: '0.9.0',
   meson_version: '>= 0.64.0',
   license: 'LGPL-2.1-or-later',
   default_options: [
@@ -8,13 +8,11 @@ project('clapper-enhancers', 'c',
   ],
 )
 
-enhancers_version = meson.project_version().split('-')[0]
-version_array = enhancers_version.split('.')
-
 glib_req = '>= 2.76.0'
-clapper_req = '>= @0@.@1@'.format(version_array[0], version_array[1])
+clapper_req = '>= 0.8.0'
 
-clapper_api_name = 'clapper-@0@.0'.format(version_array[0])
+clapper_ver_array = clapper_req.split('=')[-1].strip().split('.')
+clapper_api_name = 'clapper-@0@.0'.format(clapper_ver_array[0])
 
 optimization = get_option('optimization')
 build_optimized = optimization in ['2', '3', 's']

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,8 +1,13 @@
 # Build
 option('enhancersdir',
-  type : 'string',
-  value : '',
-  description : 'Set custom enhancers install directory'
+  type: 'string',
+  value: '',
+  description: 'Set custom enhancers install directory'
+)
+option('enhancersver',
+  type: 'string',
+  value: '',
+  description: 'Set custom enhancers version string'
 )
 
 # Enhancers

--- a/src/gen-version.py
+++ b/src/gen-version.py
@@ -18,22 +18,25 @@
 import datetime, subprocess, sys
 
 template = open(sys.argv[1]).read()
-version = sys.argv[2]
 
-try:
-    tagged = subprocess.check_output(["git", "tag", "--points-at", "HEAD"]).decode().split()
-    dirty = subprocess.check_output(["git", "describe", "--dirty"]).decode().strip().endswith("-dirty")
-    if not tagged or dirty:
-        if dirty:
-            timestamp = int(datetime.datetime.utcnow().timestamp())
-        else:
-            timestamp = subprocess.check_output(["git", "log", "-1", "--format=%ct"]).decode().strip()
-        sha = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode().strip()
-        version += f"+git.{timestamp}~{sha}"
-        if dirty:
-            version += "-dirty"
-except Exception:
-    pass
+if sys.argv[3]:
+    version = sys.argv[3]
+else:
+    version = sys.argv[2]
+    try:
+        tagged = subprocess.check_output(["git", "tag", "--points-at", "HEAD"]).decode().split()
+        dirty = subprocess.check_output(["git", "describe", "--dirty"]).decode().strip().endswith("-dirty")
+        if not tagged or dirty:
+            if dirty:
+                timestamp = int(datetime.datetime.utcnow().timestamp())
+            else:
+                timestamp = subprocess.check_output(["git", "log", "-1", "--format=%ct"]).decode().strip()
+            sha = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode().strip()
+            version += f"+git.{timestamp}~{sha}"
+            if dirty:
+                version += "-dirty"
+    except Exception:
+        pass
 
 out = template.replace("@VERSION@", version)
 sys.stdout.write(out)

--- a/src/gen-version.py
+++ b/src/gen-version.py
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2025 Rafał Dzięgiel <rafostar.github@gmail.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, see
+# <https://www.gnu.org/licenses/>.
+
+import datetime, subprocess, sys
+
+template = open(sys.argv[1]).read()
+version = sys.argv[2]
+
+try:
+    tagged = subprocess.check_output(["git", "tag", "--points-at", "HEAD"]).decode().split()
+    dirty = subprocess.check_output(["git", "describe", "--dirty"]).decode().strip().endswith("-dirty")
+    if not tagged or dirty:
+        if dirty:
+            timestamp = int(datetime.datetime.utcnow().timestamp())
+        else:
+            timestamp = subprocess.check_output(["git", "log", "-1", "--format=%ct"]).decode().strip()
+        sha = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode().strip()
+        version += f"+git.{timestamp}~{sha}"
+        if dirty:
+            version += "-dirty"
+except Exception:
+    pass
+
+out = template.replace("@VERSION@", version)
+sys.stdout.write(out)

--- a/src/meson.build
+++ b/src/meson.build
@@ -79,7 +79,7 @@ foreach name : clapper_possible_enhancers
           custom_target(enhancer_plugin_template,
             input: join_paths(name, enhancer_plugin_template),
             output: enhancer_plugin_template.replace('.in', ''),
-            command: [py, files('gen-version.py'), '@INPUT@', meson.project_version()],
+            command: [py, files('gen-version.py'), '@INPUT@', meson.project_version(), get_option('enhancersver')],
             capture: true,
             build_by_default: true,
             build_always_stale: true,

--- a/src/meson.build
+++ b/src/meson.build
@@ -75,12 +75,14 @@ foreach name : clapper_possible_enhancers
       endif
       if enhancer_available
         if enhancer_plugin_template != ''
-          plugin_conf = configuration_data()
-          plugin_conf.set('VERSION', meson.project_version())
-          configure_file(
+          py = import('python').find_installation()
+          custom_target(enhancer_plugin_template,
             input: join_paths(name, enhancer_plugin_template),
             output: enhancer_plugin_template.replace('.in', ''),
-            configuration: plugin_conf,
+            command: [py, files('gen-version.py'), '@INPUT@', meson.project_version()],
+            capture: true,
+            build_by_default: true,
+            build_always_stale: true,
             install: true,
             install_dir: enhancer_install_dir,
           )


### PR DESCRIPTION
When building from untagged or dirty git repo, extend version information with git commit timestamp and SHA. If dirty, use current timestamp and also append "-dirty" suffix.

This helps to determine which exact commit is used and ensures that enhancers cache is always rebuild during development for easier testing.