### PR TITLE
mpris: Support all possible media tags and artwork

### DIFF
--- a/src/mpris/clapper-mpris.c
+++ b/src/mpris/clapper-mpris.c
@@ -315,11 +315,17 @@ _mpris_build_track_metadata (ClapperMpris *self, ClapperMprisTrack *track)
   g_variant_builder_add (&builder, "{sv}", "mpris:length",
       g_variant_new_int64 (CLAPPER_MPRIS_SECONDS_TO_USECONDS (
       clapper_media_item_get_duration (track->item))));
-  g_variant_builder_add (&builder, "{sv}", "xesam:url",
-      g_variant_new_string (clapper_media_item_get_uri (track->item)));
   if ((str_val = clapper_media_item_get_title (track->item))) {
     g_variant_builder_add (&builder, "{sv}", "xesam:title",
         g_variant_new_take_string (str_val));
+  }
+
+  if ((str_val = clapper_media_item_get_redirect_uri (track->item))) {
+    g_variant_builder_add (&builder, "{sv}", "xesam:url",
+        g_variant_new_take_string (str_val));
+  } else {
+    g_variant_builder_add (&builder, "{sv}", "xesam:url",
+        g_variant_new_string (clapper_media_item_get_uri (track->item)));
   }
 
   tags = clapper_media_item_get_tags (track->item);

--- a/src/mpris/clapper-mpris.c
+++ b/src/mpris/clapper-mpris.c
@@ -779,11 +779,12 @@ clapper_mpris_queue_item_added (ClapperReactable *reactable, ClapperMediaItem *i
   clapper_mpris_refresh_track_list (self);
   clapper_mpris_refresh_can_go_next_previous (self);
 
-  variant = _mpris_build_track_metadata (self, track);
+  variant = g_variant_take_ref (_mpris_build_track_metadata (self, track));
 
   /* NoTrack when item is added at first position in queue */
   clapper_mpris_media_player2_track_list_emit_track_added (self->tracks_skeleton,
       variant, (prev_track != NULL) ? prev_track->id : CLAPPER_MPRIS_NO_TRACK);
+  g_variant_unref (variant);
 }
 
 static void

--- a/src/mpris/meson.build
+++ b/src/mpris/meson.build
@@ -8,7 +8,7 @@ if not os_supported
   subdir_done()
 endif
 
-if not clapper_dep.found() or not clapper_dep.version().version_compare('>= 0.9.0')
+if not clapper_dep.found() or not clapper_dep.version().version_compare('>= 0.9.1')
   if enhancer_option.enabled()
     error('@0@ enhancer was enabled, but Clapper version requirement is not met'.format(name))
   endif

--- a/src/mpris/meson.build
+++ b/src/mpris/meson.build
@@ -31,6 +31,11 @@ clapper_mpris_gdbus = gnome.gdbus_codegen('clapper-mpris-gdbus',
   namespace: 'ClapperEnhancerMpris', # FIXME: 1.0: Rename to ClapperMpris
 )
 
+config_h = configuration_data()
+config_h.set_quoted('CLAPPER_API_NAME', clapper_api_name)
+
+configure_file(output: 'config.h', configuration: config_h)
+
 enhancer_plugin_template = 'clapper-mpris.plugin.in'
 
 enhancer_deps += [


### PR DESCRIPTION
Expand MPRIS support for all metadata that specification lists that we can read from GStreamer tags. To make MPRIS complete feature-wise, also add support artwork/images in media. These will be unpacked from media item tags and written to an application specific runtime directory (ramdisk) that clients can access (MPRIS metadata uses art URL only, not data).