### PR TITLE
yt-dlp: Expanded media tags support

### DIFF
--- a/src/yt-dlp/clapper_yt_dlp.py
+++ b/src/yt-dlp/clapper_yt_dlp.py
@@ -37,6 +37,7 @@ import clapper_yt_dlp_dash as dash
 import clapper_yt_dlp_hls as hls
 import clapper_yt_dlp_direct as direct
 import clapper_yt_dlp_playlist as playlist
+import clapper_yt_dlp_utils as utils
 
 # NOTE: GStreamer does not support mp3 and opus in HLS yet
 FORMAT_PREFERENCE = '/'.join([
@@ -219,6 +220,8 @@ class ClapperYtDlp(*bases):
                 for index, chap in enumerate(val):
                     title, start, end = chap.get('title'), chap.get('start_time'), chap.get('end_time')
                     harvest.toc_add(Gst.TocEntryType.CHAPTER, title, start, end)
+            if (th := info.get('thumbnails')) and (val := utils.fetch_image_sample(th, cancellable)):
+                harvest.tags_add(Gst.TAG_PREVIEW_IMAGE, val)
 
             # Find and merge headers for requested formats
             req_headers = {}

--- a/src/yt-dlp/clapper_yt_dlp.py
+++ b/src/yt-dlp/clapper_yt_dlp.py
@@ -216,6 +216,9 @@ class ClapperYtDlp(*bases):
                 harvest.tags_add(Gst.TAG_ARTIST, val)
             if (val := info.get('description')):
                 harvest.tags_add(Gst.TAG_DESCRIPTION, val)
+            if (cats := info.get('categories')):
+                for val in cats:
+                    harvest.tags_add(Gst.TAG_GENRE, val)
             if (val := info.get('chapters')):
                 for index, chap in enumerate(val):
                     title, start, end = chap.get('title'), chap.get('start_time'), chap.get('end_time')

--- a/src/yt-dlp/clapper_yt_dlp.py
+++ b/src/yt-dlp/clapper_yt_dlp.py
@@ -229,18 +229,7 @@ class ClapperYtDlp(*bases):
                 continue
 
             item = Clapper.MediaItem(uri=entry['url'])
-            tags = Gst.TagList.new_empty()
-            tags.set_scope(Gst.TagScope.GLOBAL)
-
-            if (val := entry.get('title')):
-                tags.add_value(Gst.TagMergeMode.REPLACE, Gst.TAG_TITLE, val)
-            if (val := entry.get('duration')):
-                value = GObject.Value()
-                value.init(GObject.TYPE_UINT64)
-                value.set_uint64(val * Gst.SECOND)
-                tags.add_value(Gst.TagMergeMode.REPLACE, Gst.TAG_DURATION, value)
-
-            item.populate_tags(tags)
+            utils.playlist_item_add_tags(item, entry)
             plist.append(item)
 
         return True

--- a/src/yt-dlp/clapper_yt_dlp.py
+++ b/src/yt-dlp/clapper_yt_dlp.py
@@ -211,6 +211,10 @@ class ClapperYtDlp(*bases):
                 value.init(GObject.TYPE_UINT64)
                 value.set_uint64(val * Gst.SECOND)
                 harvest.tags_add(Gst.TAG_DURATION, value)
+            if (val := info.get('channel')):
+                harvest.tags_add(Gst.TAG_ARTIST, val)
+            if (val := info.get('description')):
+                harvest.tags_add(Gst.TAG_DESCRIPTION, val)
             if (val := info.get('chapters')):
                 for index, chap in enumerate(val):
                     title, start, end = chap.get('title'), chap.get('start_time'), chap.get('end_time')

--- a/src/yt-dlp/clapper_yt_dlp_utils.py
+++ b/src/yt-dlp/clapper_yt_dlp_utils.py
@@ -113,3 +113,18 @@ def harvest_add_item_data(harvest: Clapper.Harvest, info, cancellable: Gio.Cance
         debug.print_leveled(Gst.DebugLevel.DEBUG, f'Merged HTTP headers: {json_str}')
 
     [harvest.headers_set(key, val) for key, val in req_headers.items()]
+
+def playlist_item_add_tags(item: Clapper.MediaItem, entry):
+    tags = Gst.TagList.new_empty()
+    tags.set_scope(Gst.TagScope.GLOBAL)
+
+    # Add tags useful for a queued item (before playback)
+    if (val := entry.get('title')):
+        tags.add_value(Gst.TagMergeMode.REPLACE, Gst.TAG_TITLE, val)
+    if (val := entry.get('duration')):
+        value = GObject.Value()
+        value.init(GObject.TYPE_UINT64)
+        value.set_uint64(val * Gst.SECOND)
+        tags.add_value(Gst.TagMergeMode.REPLACE, Gst.TAG_DURATION, value)
+
+    item.populate_tags(tags)

--- a/src/yt-dlp/clapper_yt_dlp_utils.py
+++ b/src/yt-dlp/clapper_yt_dlp_utils.py
@@ -126,5 +126,7 @@ def playlist_item_add_tags(item: Clapper.MediaItem, entry):
         value.init(GObject.TYPE_UINT64)
         value.set_uint64(val * Gst.SECOND)
         tags.add_value(Gst.TagMergeMode.REPLACE, Gst.TAG_DURATION, value)
+    if (val := entry.get('channel')):
+        tags.add_value(Gst.TagMergeMode.REPLACE, Gst.TAG_ARTIST, val)
 
     item.populate_tags(tags)

--- a/src/yt-dlp/clapper_yt_dlp_utils.py
+++ b/src/yt-dlp/clapper_yt_dlp_utils.py
@@ -1,0 +1,74 @@
+# Clapper Enhancer yt-dlp
+# Copyright (C) 2025 Rafał Dzięgiel <rafostar.github@gmail.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, see
+# <https://www.gnu.org/licenses/>.
+
+import os, gi
+gi.require_version('GLib', '2.0')
+gi.require_version('Gio', '2.0')
+gi.require_version('Gst', '1.0')
+from gi.repository import GLib, Gio, Gst
+
+import clapper_yt_dlp_debug as debug
+
+def fetch_image_sample(thumbnails, cancellable: Gio.Cancellable):
+    best = None
+    best_ext = None
+    best_area = 1
+
+    debug.print_leveled(Gst.DebugLevel.DEBUG, 'Fetching image sample...')
+
+    for t in thumbnails:
+        width = t.get('width') or 0
+        height = t.get('height') or 0
+
+        if (area := width * height) < best_area or not (url := t.get('url')):
+            continue
+
+        ext = os.path.splitext(url.split('?')[0])[1][1:].lower()
+        ext = {'jpg': 'jpeg'}.get(ext, ext)
+
+        # Extensions for "image/" caps
+        if ext in ['jpeg', 'webp', 'png']:
+            best = t
+            best_ext = ext
+            best_area = area
+
+    if not best:
+        return None
+
+    file = Gio.File.new_for_uri(best['url'])
+    gbytes = None
+
+    try:
+        gbytes, _ = file.load_bytes(cancellable)
+    except GLib.Error as e:
+        # Just print, continue extraction without thumbnail
+        debug.print_leveled(Gst.DebugLevel.ERROR, f'Thumbnail fetch failed: {e.message}')
+        return None
+
+    if gbytes.get_size() == 0:
+        debug.print_leveled(Gst.DebugLevel.ERROR, 'Fetched thumbnail is empty')
+        return None
+
+    debug.print_leveled(Gst.DebugLevel.DEBUG, 'Fetched image sample')
+
+    buffer = Gst.Buffer.new_wrapped_bytes(gbytes)
+
+    caps = Gst.Caps.new_empty_simple(f'image/{best_ext}')
+    caps.set_value('width', best['width'])
+    caps.set_value('height', best['height'])
+
+    return Gst.Sample.new(buffer, caps, None, None)

--- a/src/yt-dlp/meson.build
+++ b/src/yt-dlp/meson.build
@@ -8,6 +8,7 @@ enhancer_data += [
   'yt-dlp/clapper_yt_dlp_hls.py',
   'yt-dlp/clapper_yt_dlp_direct.py',
   'yt-dlp/clapper_yt_dlp_playlist.py',
+  'yt-dlp/clapper_yt_dlp_utils.py',
 ]
 
 # Enhancer code has Clapper version checks


### PR DESCRIPTION
Add more media item tags support to yt-dlp based enhancer. Allows apps to access more video data such as: channel name, media description, genre and preview image.

In cases of playlist extraction, use preview image URI as a sample that contains "text/uri-list". This does not require us to do additional multiple requests to fetch each playlist item image and GStreamer officially supports (according to its documentation) URIs as image sample too.

Due to the above, also add sample artwork in the form of URI (instead of image data) handling in MPRIS, to make all this work together.